### PR TITLE
Bump required colcon-core version to 0.7.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  colcon-core>=0.5.2
+  colcon-core>=0.7.1
 packages = find:
 tests_require =
   pep8-naming


### PR DESCRIPTION
The dependencies in the setup.cfg should match the dependencies in stdeb.cfg.