### PR TITLE
Suppress a deprecation warning in scspell

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,8 @@ zip_safe = true
 [tool:pytest]
 filterwarnings =
     error
+    # Suppress deprecation warnings in other packages
+    ignore:lib2to3 package is deprecated::scspell
 junit_suite_name = colcon-hardware-acceleration
 
 [options.entry_points]


### PR DESCRIPTION
This same deprecation was necessary in pretty much all of the colcon packages for at least some of the platforms.

Example:
https://github.com/colcon/colcon-core/blob/b1e064aac42f6abd2fbc3d2fc06927fb12b5454c/setup.cfg#L68-L69