### PR TITLE
Use extras_require[test] instead of tests_require

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,13 +26,15 @@ keywords = colcon
 install_requires =
   colcon-core>=0.5.2
 packages = find:
-tests_require =
+zip_safe = true
+
+[options.extras_require]
+test =
   pep8-naming
   pylint
   pytest
   pytest-cov
   scspell3k>=2.2
-zip_safe = true
 
 [tool:pytest]
 filterwarnings =


### PR DESCRIPTION
This same change was applied to all of the colcon packages and is a prerequisite to using the `colcon/ci` GitHub Action.

Example: colcon/colcon-core#444