### PR TITLE
Fix long_description file name for README.md

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
     Topic :: Software Development :: Build Tools
 license = Apache License, Version 2.0
 description = Extension for colcon to include hardware acceleration
-long_description = file: README.rst
+long_description = file: README.md
 keywords = colcon
 
 [options]


### PR DESCRIPTION
```
/usr/lib/python3.11/site-packages/setuptools/config/expand.py:142: UserWarning: File 'src/colcon-hardware-acceleration/README.rst' cannot be found
  warnings.warn(f"File {path!r} cannot be found")
```