### PR TITLE
Address invalid escape sequences in strings

### DIFF
--- a/colcon_hardware_acceleration/subverb/__init__.py
+++ b/colcon_hardware_acceleration/subverb/__init__.py
@@ -408,7 +408,7 @@ def mount_rawimage(rawimage_path, partition=1, debug=False):
 
     # fetch UNITS
     units = None
-    cmd = "fdisk -l " + rawimage_path + " | grep 'Units\|Unidades' | awk '{print $8}'"
+    cmd = "fdisk -l " + rawimage_path + " | grep 'Units\\|Unidades' | awk '{print $8}'"
     outs, errs = run(cmd, shell=True)
     if outs:
         units = int(outs)
@@ -682,7 +682,7 @@ def copy_colcon_workspace(install_dir):  # noqa: D102
 
     # fetch UNITS
     units = None
-    cmd = "fdisk -l " + rawimage_path + " | grep 'Units\|Unidades' | awk '{print $8}'"
+    cmd = "fdisk -l " + rawimage_path + " | grep 'Units\\|Unidades' | awk '{print $8}'"
     outs, errs = run(cmd, shell=True)
     if outs:
         units = int(outs)
@@ -921,7 +921,7 @@ def fix_yocto_honister(partition=2):  # noqa: D102
     - /etc/profile.d/ros/setup.sh and
     - /usr/bin/ros_setup.bash
     """
-    content_etc_profile = """
+    content_etc_profile = r"""
 # generated from ament_package/template/prefix_level/setup.sh.in
 
 # since this file is sourced use either the provided AMENT_CURRENT_PREFIX
@@ -1068,7 +1068,7 @@ unset _UNIQUE_PREFIX_PATH
 unset AMENT_SHELL
 """
 
-    content_usr_bin = """
+    content_usr_bin = r"""
 # copied from ament_package/template/prefix_level/setup.bash
 
 AMENT_SHELL=bash

--- a/colcon_hardware_acceleration/subverb/emulation.py
+++ b/colcon_hardware_acceleration/subverb/emulation.py
@@ -276,7 +276,7 @@ class EmulationSubverb(AccelerationSubverbExtensionPoint):
             cmd = (
                 "fdisk -l "
                 + rawimage_path
-                + " | grep 'Units\|Unidades' | awk '{print $8}'"
+                + " | grep 'Units\\|Unidades' | awk '{print $8}'"
             )
             outs, errs = run(cmd, shell=True)
             if outs:


### PR DESCRIPTION
The backslash character is an escape sequence in Python strings. These strings contain backslashes which do not intend to escape the following character, but rather include the backslash in the string.

There are two possible resolutions:
1. Make the string a "raw" string by prefixing it with "r". This effectively makes backslashes into a normal character.
2. Escape the backslashes with another backslash.

I used both approaches in this change where appropriate.

Should resolve:
```
install/lib/python3.12/site-packages/colcon_hardware_acceleration/subverb/__init__.py:411: SyntaxWarning: invalid escape sequence '\|'
  cmd = "fdisk -l " + rawimage_path + " | grep 'Units\|Unidades' | awk '{print $8}'"
install/lib/python3.12/site-packages/colcon_hardware_acceleration/subverb/__init__.py:685: SyntaxWarning: invalid escape sequence '\|'
  cmd = "fdisk -l " + rawimage_path + " | grep 'Units\|Unidades' | awk '{print $8}'"
install/lib/python3.12/site-packages/colcon_hardware_acceleration/subverb/__init__.py:924: SyntaxWarning: invalid escape sequence '\$'
  content_etc_profile = """
install/lib/python3.12/site-packages/colcon_hardware_acceleration/subverb/emulation.py:279: SyntaxWarning: invalid escape sequence '\|'
  + " | grep 'Units\|Unidades' | awk '{print $8}'"
```

(note that I have not tested the functionality of this extension, and there are no tests for it. I only know that it clears the warnings and builds successfully.)